### PR TITLE
Basic groundtype rendering, split tileset stuff into separate class

### DIFF
--- a/data/TerrainShaderFragment.frag
+++ b/data/TerrainShaderFragment.frag
@@ -1,6 +1,6 @@
 #version 330 core
 
-varying vec3 VaryingTextureCoordinates;
+varying vec2 VaryingTextureCoordinates;
 
 uniform sampler2D Texture;
 
@@ -8,8 +8,6 @@ layout(location = 0) out vec4 Color;
 
 void main()
 {
-	//Color = texture(Texture, VaryingTextureCoordinates);
-	Color.rgb = texture(Texture, VaryingTextureCoordinates.xy).rgb;
-	Color.a = VaryingTextureCoordinates.z;
+	Color = texture(Texture, VaryingTextureCoordinates);
 	//Color = vec4(1.0, 1.0, 1.0, 1.0);
 }

--- a/data/TerrainShaderVertex.vs
+++ b/data/TerrainShaderVertex.vs
@@ -1,22 +1,15 @@
 #version 330 core
 
 attribute vec4 VertexCoordinates;
-attribute vec3 TextureCoordinates;
-attribute vec3 TextureGroundCoordinates;
+attribute vec2 TextureCoordinates;
 
 uniform mat4 ViewProjection;
 uniform mat4 Model;
-uniform int Pass;
 
-varying vec3 VaryingTextureCoordinates;
+varying vec2 VaryingTextureCoordinates;
 
 void main()
 {
     gl_Position = ViewProjection * Model * VertexCoordinates;
-	if(Pass == 0) {
-		VaryingTextureCoordinates = TextureCoordinates;
-	} else {
-		VaryingTextureCoordinates = TextureCoordinates;
-
-	}
+	VaryingTextureCoordinates = TextureCoordinates;
 }

--- a/src/World3d.cpp
+++ b/src/World3d.cpp
@@ -80,10 +80,13 @@ World3d::World3d(WZmap* m, SDL_Renderer *r) {
 	}
 	this->map = m;
 	Ter.GetHeightmapFromMWT(this->map);
+	// data involving ground types 'n' stuff (tm)
 	char* datapath = secure_getenv("WZMAP_DATA_PATH")?:(char*)"./data/";
-	Ter.CreateTexturePage(datapath, 128, Renderer);
 	Ter.LoadTerrainGrounds(datapath);
-	Ter.LoadTerrainGroundTypes(datapath);
+	Ter.LoadTerrainGroundTypes(datapath, Renderer);
+	Ter.AssociateGroundTypesWithTileGrounds();
+	//
+	Ter.CreateTexturePage(datapath, 128, Renderer);
 	Ter.UpdateTexpageCoords();
 	Ter.CreateShader();
 	Ter.BufferData();

--- a/src/World3d.cpp
+++ b/src/World3d.cpp
@@ -79,14 +79,16 @@ World3d::World3d(WZmap* m, SDL_Renderer *r) {
 		abort();
 	}
 	this->map = m;
-	Ter.GetHeightmapFromMWT(this->map);
-	// data involving ground types 'n' stuff (tm)
 	char* datapath = secure_getenv("WZMAP_DATA_PATH")?:(char*)"./data/";
-	Ter.LoadTerrainGrounds(datapath);
-	Ter.LoadTerrainGroundTypes(datapath, Renderer);
-	Ter.AssociateGroundTypesWithTileGrounds();
+	// data involving ground types 'n' stuff (tm)
+	Tst.tileset = map->tileset;
+	Tst.LoadTerrainGrounds(datapath);
+	Tst.LoadTerrainGroundTypes(datapath, Renderer);
+	Tst.AssociateGroundTypesWithTileGrounds();
+	Tst.CreateTexturePage(datapath, 128, Renderer);
+	Ter.TilesetPtr = &Tst;
 	//
-	Ter.CreateTexturePage(datapath, 128, Renderer);
+	Ter.GetHeightmapFromMWT(this->map);
 	Ter.UpdateTexpageCoords();
 	Ter.CreateShader();
 	Ter.BufferData();

--- a/src/World3d.h
+++ b/src/World3d.h
@@ -45,6 +45,7 @@ public:
 	WZmap* map;
 	std::vector<Object3d*> Objects;
 	std::vector<Texture*> Textures;
+	Tileset Tst;
 	Terrain Ter;
 	SDL_Renderer *Renderer;
 	World3d(WZmap *m, SDL_Renderer *r);

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -35,7 +35,6 @@ void Terrain::GetHeightmapFromMWT(WZmap* map) {
 		log_error("WMT failed to read map!");
 		return;
 	}
-	tileset = map->tileset;
 	w = map->maptotalx;
 	h = map->maptotaly;
 	RenderingMode = GL_TRIANGLES;
@@ -137,240 +136,6 @@ const char* TerrainTilesetToString(WZtileset t) {
 	return "unknown";
 }
 
-// Accepts path to directory with textures and qual as quality of tiles
-// qual can be 16, 32, 64 or 128
-void Terrain::CreateTexturePage(char* basepath, int qual, SDL_Renderer* rend) {
-	log_info("Loading tiles");
-	int tilesetnum = GetTerrainTilesetNumber(tileset);
-	char* folderpath = sprcatr(NULL, "%stexpages/tertilesc%dhw-%d/", basepath, tilesetnum, qual);
-	log_trace("Folder path to search tiles: [%s]", folderpath);
-	int TotalTextures = 0;
-	struct TempTextures {
-		int n;
-		SDL_Texture* t;
-		int w, h;
-	} textsa[512];
-	DIR *d;
-	struct dirent *dir;
-	d = opendir(folderpath);
-	if(!d) {
-		log_error("Can not open directory for listing");
-		return;
-	}
-	log_info("Loading tiles from [%s]", folderpath);
-	while ((dir = readdir(d)) != NULL) {
-		if(equalstr(dir->d_name, ".") || equalstr(dir->d_name, "..")) {
-			continue;
-		}
-		size_t strtileidlen = 512;
-		char* strtileid = (char*)malloc(strtileidlen);
-		if(sscanf(dir->d_name, "tile-%500[0-9].pn%1[g]%c", strtileid, strtileid+strtileidlen-2, strtileid+strtileidlen-2) != 2) {
-			log_warn("Found non-matching file [%s] in texpages directory.", dir->d_name);
-			continue;
-		}
-		char* filep = sprcatr(NULL, "%s%s", folderpath, dir->d_name);
-		SDL_Texture* t = IMG_LoadTexture(rend, filep);
-		if(t == NULL) {
-			log_error("Error opening [%s] tile!", filep);
-			log_error("Details: %s (%s)", IMG_GetError(), strerror(errno));
-			continue;
-		}
-		free(filep);
-		if(TotalTextures == 511) {
-			log_fatal("Yo wtf, more than 512 tiles? Crazy...");
-			break;
-		}
-		SDL_SetTextureBlendMode(t, SDL_BLENDMODE_BLEND);
-		textsa[TotalTextures].n = atoi(strtileid);
-		textsa[TotalTextures].t = t;
-		TotalTextures++;
-		free(strtileid);
-	}
-	closedir(d);
-	log_info("Loaded %d tiles.", TotalTextures);
-	int mw = 0, mh = 0;
-	for(int i=0; i<TotalTextures; i++) {
-		SDL_QueryTexture(textsa[i].t, NULL, NULL, &textsa[i].w, &textsa[i].h);
-		if(textsa[i].w > mw) {
-			mw = textsa[i].w;
-		}
-		if(textsa[i].h > mh) {
-			mh = textsa[i].h;
-		}
-	}
-	GroundTilePage = new Texture;
-	GroundTilePage->tex = SDL_CreateTexture(rend, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, TotalTextures*mw, mh);
-	GroundTilePage->w = TotalTextures*mw;
-	GroundTilePage->h = mh;
-	DatasetLoaded = TotalTextures;
-	SDL_Texture* savedt = SDL_GetRenderTarget(rend);
-	SDL_SetRenderTarget(rend, GroundTilePage->tex);
-	SDL_RenderClear(rend);
-	for(int i=0; i<TILEGROUNDSMAX; i++) {
-		int pn = -1;
-		for(int j=0; j<TotalTextures; j++) {
-			if(textsa[j].n == i) {
-				pn = j;
-				break;
-			}
-		}
-		if (pn == -1)
-			continue;
-		SDL_Rect from = {.x=0, .y=0, .w=textsa[pn].w, .h=textsa[pn].h};
-		SDL_Rect to = {.x=i*mw, .y=0, .w=textsa[pn].w, .h=textsa[pn].h};
-		for (int j = 0; j < 4; j++) {
-			SDL_Rect toQ = to;
-			toQ.w /= 2; toQ.h /= 2;
-			if ((j & 1))
-				toQ.x += toQ.w;
-			if ((j & 2))
-				toQ.y += toQ.h;
-			int gt = TileGrounds[i].groundTypes[j];
-			if ((gt >= 0) && (gt < GTYPESMAX) && (gtypes[gt].tex))
-				SDL_RenderCopy(rend, gtypes[gt].tex, &from, &toQ);
-		}
-		SDL_RenderCopy(rend, textsa[pn].t, &from, &to);
-	}
-	for(int i=0; i<TotalTextures; i++) {
-		SDL_DestroyTexture(textsa[i].t);
-	}
-	SDL_SetRenderTarget(rend, savedt);
-	log_info("Tiles max resolution %dx%d", mw, mh);
-	free(folderpath);
-}
-
-static size_t csv_split(FILE * input, char * lineBuf, size_t bufferLen, char ** xptr, size_t xptrCount) {
-	// kept getting fscanf failures
-	fgets(lineBuf, bufferLen, input);
-	xptr[0] = lineBuf;
-	size_t xptrI = 1;
-	// be absolutely sure a null guard is in place for any possible comma
-	lineBuf[bufferLen - 1] = 0;
-	for (size_t j = 0; j < (bufferLen - 1); j++) {
-		if ((lineBuf[j] == ',') || (lineBuf[j] < 32)) {
-			lineBuf[j] = 0;
-			if (xptrI < xptrCount) {
-				xptr[xptrI++] = lineBuf + j + 1;
-			}
-		}
-	}
-	return xptrI;
-}
-
-void Terrain::LoadTerrainGrounds(char* basepath) {
-	if(basepath == NULL) {
-		log_fatal("Base path is null!");
-		return;
-	}
-	char* filename = sprcatr(NULL, "%stileset/%sground.txt", basepath, TerrainTilesetToString(this->tileset));
-	if(filename == NULL) {
-		log_fatal("Terrain grounds filename generated is null!");
-	}
-	FILE* f = fopen(filename, "r");
-	if(f == NULL) {
-		log_fatal("Failed to open [%s]", filename);
-		free(filename);
-		return;
-	}
-	int count = -1;
-	while (fgetc(f) > 44); // skip to the comma because fscanf keeps failing
-	int ret = fscanf(f, "%d\n", &count);
-	if(ret != 1) {
-		log_error("*ground.txt header fscanf failed with %d fields readed instead of 1", ret);
-	}
-	char lineBuf[80];
-	for(int i=0; i<count; i++) {
-		// kept getting fscanf failures
-		char * xptr[4];
-		size_t xptrI = csv_split(f, lineBuf, 80, xptr, 4);
-		for (size_t j = 0; j < xptrI; j++) {
-			if (strlen(xptr[j]) < 25)
-				strcpy(TileGrounds[i].names[j], xptr[j]);
-		}
-	}
-	fclose(f);
-	free(filename);
-}
-
-void Terrain::LoadTerrainGroundTypes(char *basepath, SDL_Renderer* rend) {
-	if(basepath == NULL) {
-		log_fatal("Base path is null!");
-		return;
-	}
-	int tilesetnum = GetTerrainTilesetNumber(this->tileset);
-	char* filename = sprcatr(NULL, "%stileset/tertilesc%dhwGtype.txt", basepath, tilesetnum);
-	if(filename == NULL) {
-		log_fatal("Terrain ground types filename generated is null!");
-	}
-	FILE* f = fopen(filename, "r");
-	if(f == NULL) {
-		log_fatal("Failed to open [%s]", filename);
-		free(filename);
-		return;
-	}
-	int r = -2;
-	int typesnum = -1;
-	while (fgetc(f) > 44); // skip to the comma because fscanf keeps failing
-	r = fscanf(f, "%d\n", &typesnum);
-	if(r != 1) {
-		log_error("hwGtype header fscanf failed, returned %d", r);
-	}
-	if(typesnum > GTYPESMAX) {
-		log_warn("Too many gtypes loading, turncating %d -> %d", typesnum, GTYPESMAX);
-		typesnum = GTYPESMAX;
-	}
-	log_info("Loading %d terrain types...", typesnum);
-	gtypescount = typesnum;
-	char lineBuf[80];
-	for(int i=0; i<typesnum; i++) {
-		// kept getting fscanf failures
-		char * xptr[3];
-		if (csv_split(f, lineBuf, 80, xptr, 3) != 3) {
-			log_error("fscanf readed %d fields instead of %d on %d element.", r, 3, i);
-			continue;
-		}
-		strcpy(gtypes[i].groundtype, xptr[0]);
-		strcpy(gtypes[i].pagename, xptr[1]);
-		gtypes[i].size = atof(xptr[2]);
-	}
-	fclose(f);
-	free(filename);
-	// TODO free this
-	log_info("Ground types loaded.");
-	LoadGroundTypesTextures(basepath, rend);
-}
-
-void Terrain::AssociateGroundTypesWithTileGrounds() {
-	for (int i = 0; i < TILEGROUNDSMAX; i++) {
-		auto & tg = TileGrounds[i];
-		for (int j = 0; j < 4; j++) {
-			for (int k = 0; k < gtypescount; k++) {
-				auto & gt = gtypes[k];
-				if (!strcmp(tg.names[j], gt.groundtype)) {
-					// log_info("Association %i : GT %s", i, gt.groundtype);
-					tg.groundTypes[j] = k;
-					break;
-				}
-			}
-		}
-	}
-}
-
-void Terrain::LoadGroundTypesTextures(char* basepath, SDL_Renderer* rend) {
-	for(int i=0; i<gtypescount; i++) {
-		char* path = sprcatr(NULL, "%stexpages/%s", basepath, gtypes[i].pagename);
-		log_debug("%02d Loading page [%s]", i, path);
-		gtypes[i].tex = IMG_LoadTexture(rend, path);
-		if (!gtypes[i].tex) {
-			log_error("Failed to load ground type %i's page [%s], expect oddities", i, path);
-			log_error("Details: %s (%s)", IMG_GetError(), strerror(errno));
-		}
-		free(path);
-	}
-	log_info("Ground textures loaded");
-	// TODO free this
-}
-
 void Terrain::ConstructGroundAlphas() {
 	if(groundalphas) {
 		free(groundalphas);
@@ -389,9 +154,11 @@ void Terrain::ConstructGroundAlphas() {
 
 void Terrain::UpdateTexpageCoords() {
 	int filled = 0;
-	int tw = GroundTilePage->w/DatasetLoaded;
-	log_info("%d %d %d", tw, GroundTilePage->w, DatasetLoaded);
-	// // int th = GroundTilePage->h;
+	int tileCount = TilesetPtr->DatasetLoaded;
+	auto tilePage = TilesetPtr->GroundTilePage;
+	int tw = tilePage->w/tileCount;
+	log_info("%d %d %d", tw, tilePage->w, tileCount);
+	// // int th = tilePage->h;
 	auto SetNextTriangle = [&] (float c[2]) {
 		auto vtx = glVerticesTerrain + filled;
 		vtx->ux = c[0];
@@ -407,10 +174,10 @@ void Terrain::UpdateTexpageCoords() {
 		for(int x=0; x<w-1; x++) {
 			// 0 1
 			// 3 2
-			float tex0[4][2] = {{(tiles[x][y].texture+0)/(float)DatasetLoaded, 0.0f},
-								{(tiles[x][y].texture+1)/(float)DatasetLoaded, 0.0f},
-								{(tiles[x][y].texture+1)/(float)DatasetLoaded, 1.0f},
-								{(tiles[x][y].texture+0)/(float)DatasetLoaded, 1.0f}};
+			float tex0[4][2] = {{(tiles[x][y].texture+0)/(float)tileCount, 0.0f},
+								{(tiles[x][y].texture+1)/(float)tileCount, 0.0f},
+								{(tiles[x][y].texture+1)/(float)tileCount, 1.0f},
+								{(tiles[x][y].texture+0)/(float)tileCount, 1.0f}};
 			int tord[6];
 			if(tiles[x][y].triflip) {
 				// 1 2
@@ -499,9 +266,8 @@ void Terrain::RenderV(glm::mat4 view) {
 
 void Terrain::Render() {
 	int shader = this->TerrainShader->program;
-	if(GroundTilePage != nullptr) {
-		GroundTilePage->Bind(0);
-	}
+	auto tilePage = TilesetPtr->GroundTilePage;
+	tilePage->Bind(0);
 	glUniform1i(glGetUniformLocation(shader, "Texture"), 0);
 	glUniformMatrix4fv(glGetUniformLocation(shader, "Model"), 1, GL_FALSE, glm::value_ptr(GetMatrix()));
 	BindVAO();
@@ -512,7 +278,5 @@ void Terrain::Render() {
 		glPolygonMode( GL_FRONT_AND_BACK, GL_LINE );
 	}
 	glDrawArrays(RenderingMode, 0, GLvertexesCount);
-	if(GroundTilePage != nullptr) {
-		GroundTilePage->Unbind();
-	}
+	tilePage->Unbind();
 }

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -29,11 +29,18 @@
 extern char* texpagesPath;
 
 #define GTYPESMAX 15
+#define TILEGROUNDSMAX 120
 
 /* The shift on a world coordinate to get the tile coordinate */
 #define TILE_SHIFT 7
 static inline int32_t world_coord(int32_t mapCoord) { return (uint32_t)mapCoord << TILE_SHIFT; }
 static inline int32_t map_coord(int32_t worldCoord) { return worldCoord >> TILE_SHIFT; }
+
+// also see Terrain::BufferData
+typedef struct {
+	float x, y, z;
+	float ux, uy;
+} wme_terrain_glvertex_t;
 
 class Terrain : public Object3d {
 public:
@@ -53,18 +60,21 @@ public:
 		char groundtype[80];
 		char pagename[256];
 		double size; // wif is this for?
-		unsigned int tex;
+		SDL_Texture * tex;
 	} gtypes[GTYPESMAX];
 	int gtypescount = 0;
 	float* groundalphas = NULL;
 	struct TileGround {
 		char names[4][25] = {0}; // 25 prob. overkill but who cares at this point
-	} TileGrounds[120]; // abstract size, recheck required
-	Texture *GroundTexpage = nullptr;
+		int groundTypes[4];
+	} TileGrounds[TILEGROUNDSMAX]; // abstract size, recheck required
+	Texture *GroundTilePage = nullptr;
+	wme_terrain_glvertex_t * glVerticesTerrain = nullptr;
 	void CreateShader();
 	void LoadTerrainGrounds(char *basepath);
-	void LoadTerrainGroundTypes(char *basepath);
-	void LoadGroundTypesTextures(char *basepath);
+	void LoadTerrainGroundTypes(char *basepath, SDL_Renderer* rend);
+	void AssociateGroundTypesWithTileGrounds();
+	void LoadGroundTypesTextures(char *basepath, SDL_Renderer* rend);
 	void ConstructGroundAlphas();
 	void UpdateTexpageCoords();
 	void GetHeightmapFromMWT(WZmap* m);

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -26,10 +26,7 @@
 #include "Texture.h"
 #include "Object3d.h"
 
-extern char* texpagesPath;
-
-#define GTYPESMAX 15
-#define TILEGROUNDSMAX 120
+#include "tileset.h"
 
 /* The shift on a world coordinate to get the tile coordinate */
 #define TILE_SHIFT 7
@@ -54,31 +51,14 @@ public:
 		WMT_TerrainTypes tt;
 	} tiles[256][256];
 	int w, h;
-	WZtileset tileset;
-	int DatasetLoaded;
-	struct GroundType {
-		char groundtype[80];
-		char pagename[256];
-		double size; // wif is this for?
-		SDL_Texture * tex;
-	} gtypes[GTYPESMAX];
+	Tileset * TilesetPtr = nullptr;
 	int gtypescount = 0;
 	float* groundalphas = NULL;
-	struct TileGround {
-		char names[4][25] = {0}; // 25 prob. overkill but who cares at this point
-		int groundTypes[4];
-	} TileGrounds[TILEGROUNDSMAX]; // abstract size, recheck required
-	Texture *GroundTilePage = nullptr;
 	wme_terrain_glvertex_t * glVerticesTerrain = nullptr;
 	void CreateShader();
-	void LoadTerrainGrounds(char *basepath);
-	void LoadTerrainGroundTypes(char *basepath, SDL_Renderer* rend);
-	void AssociateGroundTypesWithTileGrounds();
-	void LoadGroundTypesTextures(char *basepath, SDL_Renderer* rend);
 	void ConstructGroundAlphas();
 	void UpdateTexpageCoords();
 	void GetHeightmapFromMWT(WZmap* m);
-	void CreateTexturePage(char* basepath, int qual, SDL_Renderer* rend);
 	void BufferData();
 	void RenderV(glm::mat4 view);
 	void Render();

--- a/src/tileset.cpp
+++ b/src/tileset.cpp
@@ -1,0 +1,265 @@
+/*
+    This file is part of WZ2100 Map Editor.
+    Copyright (C) 2020-2021  maxsupermanhd
+    Copyright (C) 2020-2021  bjorn-ali-goransson
+
+    WZ2100 Map Editor is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    WZ2100 Map Editor is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with WZ2100 Map Editor; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "tileset.h"
+
+#include <dirent.h>
+#include <SDL2/SDL_image.h>
+#include <errno.h>
+
+#include "other.h"
+
+int GetTerrainTilesetNumber(WZtileset t);
+const char* TerrainTilesetToString(WZtileset t);
+
+// Accepts path to directory with textures and qual as quality of tiles
+// qual can be 16, 32, 64 or 128
+void Tileset::CreateTexturePage(char* basepath, int qual, SDL_Renderer* rend) {
+	log_info("Loading tiles");
+	int tilesetnum = GetTerrainTilesetNumber(tileset);
+	char* folderpath = sprcatr(NULL, "%stexpages/tertilesc%dhw-%d/", basepath, tilesetnum, qual);
+	log_trace("Folder path to search tiles: [%s]", folderpath);
+	int TotalTextures = 0;
+	struct TempTextures {
+		int n;
+		SDL_Texture* t;
+		int w, h;
+	} textsa[512];
+	DIR *d;
+	struct dirent *dir;
+	d = opendir(folderpath);
+	if(!d) {
+		log_error("Can not open directory for listing");
+		return;
+	}
+	log_info("Loading tiles from [%s]", folderpath);
+	while ((dir = readdir(d)) != NULL) {
+		if(equalstr(dir->d_name, ".") || equalstr(dir->d_name, "..")) {
+			continue;
+		}
+		size_t strtileidlen = 512;
+		char* strtileid = (char*)malloc(strtileidlen);
+		if(sscanf(dir->d_name, "tile-%500[0-9].pn%1[g]%c", strtileid, strtileid+strtileidlen-2, strtileid+strtileidlen-2) != 2) {
+			log_warn("Found non-matching file [%s] in texpages directory.", dir->d_name);
+			continue;
+		}
+		char* filep = sprcatr(NULL, "%s%s", folderpath, dir->d_name);
+		SDL_Texture* t = IMG_LoadTexture(rend, filep);
+		if(t == NULL) {
+			log_error("Error opening [%s] tile!", filep);
+			log_error("Details: %s (%s)", IMG_GetError(), strerror(errno));
+			continue;
+		}
+		free(filep);
+		if(TotalTextures == 511) {
+			log_fatal("Yo wtf, more than 512 tiles? Crazy...");
+			break;
+		}
+		SDL_SetTextureBlendMode(t, SDL_BLENDMODE_BLEND);
+		textsa[TotalTextures].n = atoi(strtileid);
+		textsa[TotalTextures].t = t;
+		TotalTextures++;
+		free(strtileid);
+	}
+	closedir(d);
+	log_info("Loaded %d tiles.", TotalTextures);
+	int mw = 0, mh = 0;
+	for(int i=0; i<TotalTextures; i++) {
+		SDL_QueryTexture(textsa[i].t, NULL, NULL, &textsa[i].w, &textsa[i].h);
+		if(textsa[i].w > mw) {
+			mw = textsa[i].w;
+		}
+		if(textsa[i].h > mh) {
+			mh = textsa[i].h;
+		}
+	}
+	GroundTilePage = new Texture;
+	GroundTilePage->tex = SDL_CreateTexture(rend, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, TotalTextures*mw, mh);
+	GroundTilePage->w = TotalTextures*mw;
+	GroundTilePage->h = mh;
+	DatasetLoaded = TotalTextures;
+	SDL_Texture* savedt = SDL_GetRenderTarget(rend);
+	SDL_SetRenderTarget(rend, GroundTilePage->tex);
+	SDL_RenderClear(rend);
+	for(int i=0; i<TILEGROUNDSMAX; i++) {
+		int pn = -1;
+		for(int j=0; j<TotalTextures; j++) {
+			if(textsa[j].n == i) {
+				pn = j;
+				break;
+			}
+		}
+		if (pn == -1)
+			continue;
+		SDL_Rect from = {.x=0, .y=0, .w=textsa[pn].w, .h=textsa[pn].h};
+		SDL_Rect to = {.x=i*mw, .y=0, .w=textsa[pn].w, .h=textsa[pn].h};
+		for (int j = 0; j < 4; j++) {
+			SDL_Rect toQ = to;
+			toQ.w /= 2; toQ.h /= 2;
+			if ((j & 1))
+				toQ.x += toQ.w;
+			if ((j & 2))
+				toQ.y += toQ.h;
+			int gt = TileGrounds[i].groundTypes[j];
+			if ((gt >= 0) && (gt < GTYPESMAX) && (gtypes[gt].tex))
+				SDL_RenderCopy(rend, gtypes[gt].tex, &from, &toQ);
+		}
+		SDL_RenderCopy(rend, textsa[pn].t, &from, &to);
+	}
+	for(int i=0; i<TotalTextures; i++) {
+		SDL_DestroyTexture(textsa[i].t);
+	}
+	SDL_SetRenderTarget(rend, savedt);
+	log_info("Tiles max resolution %dx%d", mw, mh);
+	free(folderpath);
+}
+
+static size_t csv_split(FILE * input, char * lineBuf, size_t bufferLen, char ** xptr, size_t xptrCount) {
+	// kept getting fscanf failures
+	fgets(lineBuf, bufferLen, input);
+	xptr[0] = lineBuf;
+	size_t xptrI = 1;
+	// be absolutely sure a null guard is in place for any possible comma
+	lineBuf[bufferLen - 1] = 0;
+	for (size_t j = 0; j < (bufferLen - 1); j++) {
+		if ((lineBuf[j] == ',') || (lineBuf[j] < 32)) {
+			lineBuf[j] = 0;
+			if (xptrI < xptrCount) {
+				xptr[xptrI++] = lineBuf + j + 1;
+			}
+		}
+	}
+	return xptrI;
+}
+
+void Tileset::LoadTerrainGrounds(char* basepath) {
+	if(basepath == NULL) {
+		log_fatal("Base path is null!");
+		return;
+	}
+	char* filename = sprcatr(NULL, "%stileset/%sground.txt", basepath, TerrainTilesetToString(this->tileset));
+	if(filename == NULL) {
+		log_fatal("Terrain grounds filename generated is null!");
+	}
+	FILE* f = fopen(filename, "r");
+	if(f == NULL) {
+		log_fatal("Failed to open [%s]", filename);
+		free(filename);
+		return;
+	}
+	int count = -1;
+	while (fgetc(f) > 44); // skip to the comma because fscanf keeps failing
+	int ret = fscanf(f, "%d\n", &count);
+	if(ret != 1) {
+		log_error("*ground.txt header fscanf failed with %d fields readed instead of 1", ret);
+	}
+	char lineBuf[80];
+	for(int i=0; i<count; i++) {
+		// kept getting fscanf failures
+		char * xptr[4];
+		size_t xptrI = csv_split(f, lineBuf, 80, xptr, 4);
+		for (size_t j = 0; j < xptrI; j++) {
+			if (strlen(xptr[j]) < 25)
+				strcpy(TileGrounds[i].names[j], xptr[j]);
+		}
+	}
+	fclose(f);
+	free(filename);
+}
+
+void Tileset::LoadTerrainGroundTypes(char *basepath, SDL_Renderer* rend) {
+	if(basepath == NULL) {
+		log_fatal("Base path is null!");
+		return;
+	}
+	int tilesetnum = GetTerrainTilesetNumber(this->tileset);
+	char* filename = sprcatr(NULL, "%stileset/tertilesc%dhwGtype.txt", basepath, tilesetnum);
+	if(filename == NULL) {
+		log_fatal("Terrain ground types filename generated is null!");
+	}
+	FILE* f = fopen(filename, "r");
+	if(f == NULL) {
+		log_fatal("Failed to open [%s]", filename);
+		free(filename);
+		return;
+	}
+	int r = -2;
+	int typesnum = -1;
+	while (fgetc(f) > 44); // skip to the comma because fscanf keeps failing
+	r = fscanf(f, "%d\n", &typesnum);
+	if(r != 1) {
+		log_error("hwGtype header fscanf failed, returned %d", r);
+	}
+	if(typesnum > GTYPESMAX) {
+		log_warn("Too many gtypes loading, turncating %d -> %d", typesnum, GTYPESMAX);
+		typesnum = GTYPESMAX;
+	}
+	log_info("Loading %d terrain types...", typesnum);
+	gtypescount = typesnum;
+	char lineBuf[80];
+	for(int i=0; i<typesnum; i++) {
+		// kept getting fscanf failures
+		char * xptr[3];
+		if (csv_split(f, lineBuf, 80, xptr, 3) != 3) {
+			log_error("fscanf readed %d fields instead of %d on %d element.", r, 3, i);
+			continue;
+		}
+		strcpy(gtypes[i].groundtype, xptr[0]);
+		strcpy(gtypes[i].pagename, xptr[1]);
+		gtypes[i].size = atof(xptr[2]);
+	}
+	fclose(f);
+	free(filename);
+	// TODO free this
+	log_info("Ground types loaded.");
+	LoadGroundTypesTextures(basepath, rend);
+}
+
+void Tileset::AssociateGroundTypesWithTileGrounds() {
+	for (int i = 0; i < TILEGROUNDSMAX; i++) {
+		auto & tg = TileGrounds[i];
+		for (int j = 0; j < 4; j++) {
+			for (int k = 0; k < gtypescount; k++) {
+				auto & gt = gtypes[k];
+				if (!strcmp(tg.names[j], gt.groundtype)) {
+					// log_info("Association %i : GT %s", i, gt.groundtype);
+					tg.groundTypes[j] = k;
+					break;
+				}
+			}
+		}
+	}
+}
+
+void Tileset::LoadGroundTypesTextures(char* basepath, SDL_Renderer* rend) {
+	for(int i=0; i<gtypescount; i++) {
+		char* path = sprcatr(NULL, "%stexpages/%s", basepath, gtypes[i].pagename);
+		log_debug("%02d Loading page [%s]", i, path);
+		gtypes[i].tex = IMG_LoadTexture(rend, path);
+		if (!gtypes[i].tex) {
+			log_error("Failed to load ground type %i's page [%s], expect oddities", i, path);
+			log_error("Details: %s (%s)", IMG_GetError(), strerror(errno));
+		}
+		free(path);
+	}
+	log_info("Ground textures loaded");
+	// TODO free this
+}
+

--- a/src/tileset.h
+++ b/src/tileset.h
@@ -1,0 +1,59 @@
+/*
+    This file is part of WZ2100 Map Editor.
+    Copyright (C) 2020-2021  maxsupermanhd
+    Copyright (C) 2020-2021  bjorn-ali-goransson
+
+    WZ2100 Map Editor is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    WZ2100 Map Editor is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with WZ2100 Map Editor; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#ifndef TILESET_H_INCLUDED
+#define TILESET_H_INCLUDED
+
+#include "wmt.hpp"
+#include "Shader.h"
+#include "Texture.h"
+#include "Object3d.h"
+
+extern char* texpagesPath;
+
+#define GTYPESMAX 15
+#define TILEGROUNDSMAX 120
+
+class Tileset {
+public:
+	WZtileset tileset;
+	struct GroundType {
+		char groundtype[80];
+		char pagename[256];
+		double size; // wif is this for?
+		SDL_Texture * tex;
+	} gtypes[GTYPESMAX];
+	int gtypescount = 0;
+	struct TileGround {
+		char names[4][25] = {0}; // 25 prob. overkill but who cares at this point
+		int groundTypes[4];
+	} TileGrounds[TILEGROUNDSMAX]; // abstract size, recheck required
+
+	Texture *GroundTilePage = nullptr;
+	int DatasetLoaded = 0; // amount of tiles in GroundTilePage
+
+	void LoadTerrainGrounds(char *basepath);
+	void LoadTerrainGroundTypes(char *basepath, SDL_Renderer* rend);
+	void AssociateGroundTypesWithTileGrounds();
+	void LoadGroundTypesTextures(char *basepath, SDL_Renderer* rend);
+	void CreateTexturePage(char* basepath, int qual, SDL_Renderer* rend);
+};
+
+#endif /* end of include guard: TILESET_H_INCLUDED */


### PR DESCRIPTION
This is enough to make the map renderer barely usable, as cliff faces are now semi-visible. An alternative solution I did consider was simply placing a white overlay underneath tiles, but that seems less likely to be bugfixable into something approximating the actual game.

This is probably not the best solution to these problems but it is a solution, and splitting out the tileset stuff should help in changing things later.
