### PR TITLE
Fix nlohmann json include reference to account for it's placement

### DIFF
--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -21,8 +21,8 @@
 #include "stats.h"
 
 #include <fstream>
-#include <nlohmann/json.hpp>
 
+#include "json.hpp"
 #include "log.hpp"
 
 using json = nlohmann::json;


### PR DESCRIPTION
Basically, the bug:
```
/media/modus/External2/WarzoneMapEditor/src/stats.cpp:24:10: fatal error: nlohmann/json.hpp: No such file or directory
   24 | #include <nlohmann/json.hpp>
      |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
```
